### PR TITLE
feat: support a generic address type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,6 +126,7 @@ dependencies = [
  "nix",
  "paste",
  "rand",
+ "thiserror",
  "windows",
 ]
 
@@ -138,6 +139,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ path = "src/lib.rs"
 [dependencies]
 cfg-if = "1.0.0"
 paste = "1.0.15"
+thiserror = "2.0.12"
 
 [dev-dependencies]
 rand = "0.8.5"

--- a/examples/lazer.rs
+++ b/examples/lazer.rs
@@ -1,0 +1,49 @@
+use rosu_mem::{
+    error::ProcessError,
+    process::{Process, ProcessTraits},
+    signature::Signature,
+};
+use std::str::FromStr;
+
+fn main() -> Result<(), ProcessError> {
+    // Initialize a process first
+    let osu_process = Process::initialize("osu!", &[])?;
+
+    println!("Found a osu! lazer process");
+
+    // Initialize a signatures
+    let session_signature =
+        Signature::from_str("00 00 00 00 80 4F 12 41").unwrap();
+
+    // Scan process for pre-initialized signatures
+    // Be aware that osu! lazer uses usize for addresses, so we also
+    // explicitly defining that
+    // Also reading a values for lazer is bit more tidious than stable :)
+    let mut session_addr: usize =
+        osu_process.read_signature(&session_signature)?; //- 0x208;
+
+    // Read values! For simplicity willl read only a current game time
+    session_addr -= 0x208;
+
+    let one = (osu_process.read_i64(session_addr + 0x90)? + 0x90) as usize;
+    let two = (osu_process.read_i64(one)? + 0x90) as usize;
+    let three = (osu_process.read_i64(two)? + 0x90) as usize;
+    let four = (osu_process.read_i64(three)? + 0x90) as usize;
+    let five = (osu_process.read_i64(four)? + 0x90) as usize;
+    let six = (osu_process.read_i64(five)? + 0x90) as usize;
+    let seven = (osu_process.read_i64(six)? + 0x340) as usize;
+
+    let game_base = osu_process.read_i64(seven)? as usize;
+
+    println!("Read a game base!");
+
+    let beatmap_clock_ptr = osu_process.read_i64(game_base + 0x4d0)? as usize;
+    let final_clock_ptr =
+        osu_process.read_i64(beatmap_clock_ptr + 0x210)? as usize;
+
+    let current_time = osu_process.read_f64(final_clock_ptr + 0x30)?;
+
+    println!("Current osu time: {current_time}");
+
+    Ok(())
+}

--- a/examples/stable.rs
+++ b/examples/stable.rs
@@ -1,0 +1,39 @@
+use rosu_mem::{
+    error::ProcessError,
+    process::{Process, ProcessTraits},
+    signature::Signature,
+};
+use std::str::FromStr;
+
+// Exclude words, basically a hack to properly find a osu! process when using wine
+static EXCLUDE_WORDS: [&str; 2] = ["umu-run", "waitforexitandrun"];
+
+fn main() -> Result<(), ProcessError> {
+    // Initialize a process first
+    let osu_process = Process::initialize("osu!.exe", &EXCLUDE_WORDS)?;
+
+    println!("Found a osu! process");
+
+    // Initialize a signatures
+    let base_signature = Signature::from_str("F8 01 74 04 83 65").unwrap();
+    let status_signature = Signature::from_str("48 83 F8 04 73 1E").unwrap();
+
+    // Scan process for pre-initialized signatures
+    // Be aware that osu! stable uses i32 for addresses, so we also
+    // explicitly defining that
+
+    // Reading a base signature just to be sure that we are in the correct osu! process
+    let _base: i32 = osu_process.read_signature(&base_signature)?;
+    let status: i32 = osu_process.read_signature(&status_signature)?;
+
+    println!("Found all required signatures!");
+
+    // Now read the values that you are intrested in :)
+    // For the sake of keeping example simple we will read a current game state
+    let status_ptr = osu_process.read_i32(status - 0x4)?;
+    let osu_state_status = osu_process.read_u32(status_ptr)?;
+
+    println!("Current osu! game status: {osu_state_status}");
+
+    Ok(())
+}

--- a/src/address.rs
+++ b/src/address.rs
@@ -1,0 +1,22 @@
+pub enum Address {
+    Native(usize),
+    I64(i64),
+    I32(i32)
+}
+
+fn test_convert<T: TryInto<usize>>(value: T) {
+
+    let end_value: usize = value.try_into().unwrap();
+
+    println!("")
+}
+
+fn test_xd() {
+    let value_i32 = 1337i32;
+    let value_i64 = 1338i64;
+    let value_usize = 1339usize;
+
+
+    test_convert(value_i64);
+
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,6 +21,7 @@ pub enum ProcessError {
         #[cfg(target_os = "windows")]
         inner: windows::core::Error,
     },
+    ConvertError,
 }
 
 impl From<std::io::Error> for ProcessError {
@@ -85,7 +86,7 @@ impl Display for ProcessError {
                 write!(f, "Got error during type convertion")
             }
             ProcessError::SignatureNotFound(v) => {
-                write!(f, "Cannot find signature {}", v)
+                write!(f, "Cannot find signature {v}")
             }
             ProcessError::OsError { .. } => write!(f, "Got OS error"),
             ProcessError::NotEnoughPermissions => {
@@ -93,10 +94,13 @@ impl Display for ProcessError {
             }
             ProcessError::BadAddress(addr, len) => {
                 let _ = writeln!(f, "Trying to read bad address");
-                writeln!(f, "Address: {:X}, Length: {:X}", addr, len)
+                writeln!(f, "Address: {addr:X}, Length: {len:X}")
             }
             ProcessError::ExecutablePathNotFound => {
                 write!(f, "Executable path not found!")
+            }
+            ProcessError::ConvertError => {
+                write!(f, "Failed to converted passed address to usize")
             }
         }
     }
@@ -114,6 +118,7 @@ impl std::error::Error for ProcessError {
             ProcessError::SignatureNotFound(_) => None,
             ProcessError::OsError { inner } => Some(inner),
             ProcessError::BadAddress(..) => None,
+            ProcessError::ConvertError => None,
         }
     }
 }

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -151,7 +151,7 @@ impl ProcessTraits for Process {
             if let Some(offset) = find_signature(buff.as_slice(), sign) {
                 return (remote.base + offset)
                     .try_into()
-                    .map_err(|_| ProcessError::ConvertError);
+                    .map_err(|_| ProcessError::AddressConvertError);
             }
         }
 
@@ -164,8 +164,9 @@ impl ProcessTraits for Process {
         len: usize,
         buff: &mut [u8],
     ) -> Result<(), ProcessError> {
-        let addr: usize =
-            addr.try_into().map_err(|_| ProcessError::ConvertError)?;
+        let addr: usize = addr
+            .try_into()
+            .map_err(|_| ProcessError::AddressConvertError)?;
 
         let remote = RemoteIoVec { base: addr, len };
 

--- a/src/process.rs
+++ b/src/process.rs
@@ -37,7 +37,7 @@ macro_rules! prim_read_array_impl {
                 buff: &mut Vec<$t>
             ) -> Result<(), ProcessError> {
                 let addr: usize = addr.try_into()
-                    .map_err(|_| ProcessError::ConvertError)?;
+                    .map_err(|_| ProcessError::AddressConvertError)?;
 
                 let items_ptr = self.read_i32(addr + 4)?;
                 let size = self.read_i32(addr + 12)? as usize;

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -164,7 +164,7 @@ impl ProcessTraits for Process {
             if let Some(offset) = find_signature(&buf[..bytesread], sign) {
                 return (region.from + offset)
                     .try_into()
-                    .map_err(|_| ProcessError::ConvertError);
+                    .map_err(|_| ProcessError::AddressConvertError);
             }
         }
 
@@ -177,8 +177,9 @@ impl ProcessTraits for Process {
         len: usize,
         buff: &mut [u8],
     ) -> Result<(), ProcessError> {
-        let addr: usize =
-            addr.try_into().map_err(|_| ProcessError::ConvertError)?;
+        let addr: usize = addr
+            .try_into()
+            .map_err(|_| ProcessError::AddressConvertError)?;
 
         let mut n = 0;
 

--- a/tests/types.rs
+++ b/tests/types.rs
@@ -113,24 +113,26 @@ impl ProcessTraits for FakeProccess {
         todo!()
     }
 
-    fn read_signature(
+    fn read_signature<T: TryFrom<usize>>(
         &self,
         _sign: &rosu_mem::signature::Signature,
-    ) -> Result<i32, ProcessError> {
+    ) -> Result<T, ProcessError> {
         todo!()
     }
 
-    fn read(
+    fn read<T: TryInto<usize>>(
         &self,
-        addr: i32,
+        addr: T,
         len: usize,
         buff: &mut [u8],
     ) -> Result<(), ProcessError> {
+        let addr: usize =
+            addr.try_into().map_err(|_| ProcessError::ConvertError)?;
         // Addr - starting index
         // self.buff.set_position(addr as u64);
         // self.buff.read(buff);
 
-        let mut slice = &self.buff[addr as usize..addr as usize + len];
+        let mut slice = &self.buff[addr..addr + len];
         let _ = slice.read(buff);
 
         Ok(())

--- a/tests/types.rs
+++ b/tests/types.rs
@@ -126,8 +126,9 @@ impl ProcessTraits for FakeProccess {
         len: usize,
         buff: &mut [u8],
     ) -> Result<(), ProcessError> {
-        let addr: usize =
-            addr.try_into().map_err(|_| ProcessError::ConvertError)?;
+        let addr: usize = addr
+            .try_into()
+            .map_err(|_| ProcessError::AddressConvertError)?;
         // Addr - starting index
         // self.buff.set_position(addr as u64);
         // self.buff.read(buff);


### PR DESCRIPTION
- Support generic `TryInto<usize>` for addresses instead of hardcoded i32 & same for signature scanning
- Test for exclude words
- Various clippy warnings fixes
- Example for the osu! stable & osu! lazer clients
- Linux: check for the memory regions permissions